### PR TITLE
Use gson and commons-lang3 API plugins instead of jar files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,6 @@ limitations under the License.
 
   <dependencies>
 
-
     <dependency>
       <groupId>io.iron.ironmq</groupId>
       <artifactId>ironmq</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,24 @@ limitations under the License.
       <groupId>io.iron.ironmq</groupId>
       <artifactId>ironmq</artifactId>
       <version>3.0.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Revise 

Remove the inclusion of an outdated version of commons-lang3 jar file and an outdated version of gson jar file in the Jenkins plugin packaging by declaring a dependency on the Jenkins commons-lang3 API plugin and the Jenkins gson API plugin.

The transitive dependencies included through the ironmq jar file are out of date and won't be used in Jenkins installations where the API plugins    are already installed.  That will be the case in most Jenkins    controllers, so let's make this plugin use the API plugins rather than    packaging the commons-lang3 and gson jar files as transitive    dependencies.

The commons-lang3 plugin is installed on 65% of all Jenkins controllers     and is delivering the most recent release of commons-lang3.

The gson plugin is a new enough plugin that we don't have installation     count data yet, but it is expected to be widely installed as well,     since it is used in the Trilead API plugin that is installed on 93%     of Jenkins controllers.

This pull request is intentionally submitted towards the contributor repository so that @raahikwueto can consider including it in the pull request:

* https://github.com/jenkinsci/ironmq-notifier-plugin/pull/22

## Checklist

- [x] I have read the [DEVELOPER](README-developer.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
